### PR TITLE
feat: use rabby bridge URL in wagmi WalletConnectConnector

### DIFF
--- a/src/components/NotificationFeedProvider/useWagmiClient.ts
+++ b/src/components/NotificationFeedProvider/useWagmiClient.ts
@@ -39,6 +39,7 @@ export default function useWagmiClient(provider?: ExternalProvider) {
         new WalletConnectConnector({
           chains,
           options: {
+            bridge: 'https://derelay.rabby.io',
             qrcode: true,
             name: 'Wherever',
             projectId: '8702507d2e8fbe25563c45434f74cfe3',


### PR DESCRIPTION
### Description

While inspecting @walletconnect/client instantiations in ShapeShift web, noticed many instantiations of the client by wherever widget using the default bridge URL (i.e no bridge URL passed) for v1, which is now deprecated.

This uses the rabby relay URL, which comes as an effective drop-in replacement for the now deprecated bridge URL.
See:
- https://docs.walletconnect.com/2.0/advanced/migration-from-v1.x/overview#walletconnect-v10-vs-v20
- https://github.com/RabbyHub/derelay
